### PR TITLE
OracleSolaris_OCI/Launch_Solaris_with_Terraform needs to include Application Catalog subscription

### DIFF
--- a/OracleSolaris_OCI/Launch_Solaris_with_Terraform/.gitignore
+++ b/OracleSolaris_OCI/Launch_Solaris_with_Terraform/.gitignore
@@ -1,0 +1,5 @@
+*.terraform*
+terraform.tfstate
+terraform.tfstate.backup
+*.auto.tfvars
+

--- a/OracleSolaris_OCI/Launch_Solaris_with_Terraform/compute.tf
+++ b/OracleSolaris_OCI/Launch_Solaris_with_Terraform/compute.tf
@@ -6,12 +6,12 @@ resource "oci_core_instance" "solaris_instance" {
   source_details {
       source_type = "image"
       # The image ID is determined in image.tf 
-      source_id = data.oci_core_app_catalog_listing_resource_version.solaris_catalog_listing.listing_resource_id
+      source_id = data.oci_marketplace_listing_package.solaris_list_pkg.image_id
   }
 
   display_name = var.instance_display_name
   create_vnic_details {
-      assign_public_ip = true
+      # assign_public_ip = false
       subnet_id = var.subnet_id
   }
   metadata = {

--- a/OracleSolaris_OCI/Launch_Solaris_with_Terraform/image.tf
+++ b/OracleSolaris_OCI/Launch_Solaris_with_Terraform/image.tf
@@ -53,3 +53,30 @@ resource "oci_marketplace_accepted_agreement" "solaris_accepted_agreement" {
   package_version = data.oci_marketplace_listing.solaris_latest.default_package_version
   signature       = oci_marketplace_listing_package_agreement.solaris_list_pkg_agreement.signature
 }
+
+
+# As well for every new Solaris release new subscription needs to be obtained in the Application Catalog
+# (This needs to be done only once and could be done via GUI if needed)
+
+# subscription details
+resource "oci_core_app_catalog_listing_resource_version_agreement" "solaris_latest_catalog_details" {
+  listing_id               = data.oci_core_app_catalog_listing_resource_version.solaris_catalog_listing.listing_id
+  listing_resource_version = data.oci_core_app_catalog_listing_resource_version.solaris_catalog_listing.listing_resource_version
+}
+
+# signing subscription
+resource "oci_core_app_catalog_subscription" "solaris_subscription" {
+  compartment_id           = var.compartment_ocid
+  listing_id               = oci_core_app_catalog_listing_resource_version_agreement.solaris_latest_catalog_details.listing_id
+  listing_resource_version = oci_core_app_catalog_listing_resource_version_agreement.solaris_latest_catalog_details.listing_resource_version
+  oracle_terms_of_use_link = oci_core_app_catalog_listing_resource_version_agreement.solaris_latest_catalog_details.oracle_terms_of_use_link
+  signature                = oci_core_app_catalog_listing_resource_version_agreement.solaris_latest_catalog_details.signature
+  time_retrieved           = oci_core_app_catalog_listing_resource_version_agreement.solaris_latest_catalog_details.time_retrieved
+  eula_link                = oci_core_app_catalog_listing_resource_version_agreement.solaris_latest_catalog_details.eula_link
+
+  // May take long for the subscription to propagate to all regions
+  timeouts {
+    create = "20m"
+  }
+}
+

--- a/OracleSolaris_OCI/Launch_Solaris_with_Terraform/outputs.tf
+++ b/OracleSolaris_OCI/Launch_Solaris_with_Terraform/outputs.tf
@@ -5,6 +5,9 @@ output "A01_Compartment-Name" {
 output "A01_Subnet-OCID" {
   value = var.subnet_id
 }
+output "A01_VCN-OCID" {
+  value = data.oci_core_vcn.myvcn.id
+}
 
 output "A02_Shape-of-Instance" {
   value = oci_core_instance.solaris_instance.shape
@@ -84,6 +87,7 @@ output "E4_oci_core_app_catalog_listing_resource_version-resource_version" {
 output "E5_oci_core_app_catalog_listing_resource_version-additional_info" {
   value = "This object also includes lists of available_regions and compatible_shapes"
 }
+
 output "E_END" {
   value = "===================="
 }
@@ -112,10 +116,24 @@ output "G4_solaris_list_pkg_agreement-package_version" {
   value = oci_marketplace_listing_package_agreement.solaris_list_pkg_agreement.package_version
 }
 output "G5_solaris_list_pkg_agreement-signature" {
-  value = oci_marketplace_listing_package_agreement.solaris_list_pkg_agreement.signature
+  value = base64decode(oci_marketplace_listing_package_agreement.solaris_list_pkg_agreement.signature)
 }
 output "G_END" {
   value = "===================="
 }
 
-
+output "L1_oci_core_app_catalog_listing_resource_version_agreement-oracle_terms_of_use_link" {
+  value = oci_core_app_catalog_listing_resource_version_agreement.solaris_latest_catalog_details.oracle_terms_of_use_link
+}
+output "L2_oci_core_app_catalog_listing_resource_version_agreement-eula_link" {
+  value = oci_core_app_catalog_listing_resource_version_agreement.solaris_latest_catalog_details.eula_link
+}
+output "L3_oci_core_app_catalog_subscription-signature" {
+  value = oci_core_app_catalog_subscription.solaris_subscription.signature
+}
+output "L4_oci_core_app_catalog_subscription-time_retrieved" {
+  value = oci_core_app_catalog_subscription.solaris_subscription.time_retrieved
+}
+output "L_END" {
+  value = "===================="
+}

--- a/OracleSolaris_OCI/Launch_Solaris_with_Terraform/variables.tf
+++ b/OracleSolaris_OCI/Launch_Solaris_with_Terraform/variables.tf
@@ -3,15 +3,15 @@ variable "region" {
 }
 
 variable "availability_domain" {
-  default = "ruWb:PHX-AD-1"
+  default = "oscS:PHX-AD-3"
 }
 
 variable "compartment_ocid" {  
-  default = "ocid1.compartment.oc1..aaa..."
+#  default = "ocid1.compartment.oc1..aaa..."
 }
 
 variable "subnet_id" {
-  default = "ocid1.subnet.oc1.phx.aa..."
+#  default = "ocid1.subnet.oc1.phx.aa..."
 }
 
 # The next set of variables specify the instance to be created.
@@ -33,6 +33,6 @@ variable "instance_display_name" {
 
 variable "ssh_public_key_path" {
   description = "SSH Public Key Path"
-  default = "/.../.../.ssh/ocisshkey.pub"
+#  default = "/.../.../.ssh/ocisshkey.pub"
 }
 


### PR DESCRIPTION
This is a fix for issue #15

it expands the terraform example for Solaris in OCI by adding automated Application Catalog subscription, so that
the terraform plan works even if new Solaris version gets released.

