### PR TITLE
The signature in oci_marketplace_accepted_agreement is time based

### DIFF
--- a/OracleSolaris_OCI/Launch_Solaris_with_Terraform/image.tf
+++ b/OracleSolaris_OCI/Launch_Solaris_with_Terraform/image.tf
@@ -30,11 +30,18 @@ data "oci_core_app_catalog_listing_resource_version" "solaris_catalog_listing" {
 
 # Retrieve any agreements needed, which match the listing found above.
 data "oci_marketplace_listing_package_agreements" "solaris_list_pkg_agreements" {
+
+    depends_on = [ time_rotating.signature_refresh_period ]
+
     listing_id = data.oci_marketplace_listing.solaris_latest.id
     package_version = data.oci_marketplace_listing.solaris_latest.default_package_version
 }
 
-
+# the signatures in the package agreements are time based an will expire,
+# so we need to re-read the package listing once a while to replace the stale values from terraform.tfstate
+resource "time_rotating" "signature_refresh_period" {
+  rotation_days = 7
+}
 
 # Some OCI resources can only be used after you accept the terms and conditions. For the purposes
 # of automation, that acceptance is implemented as an "accepted agreement". Within the Terraform


### PR DESCRIPTION
The terraform plan example for creating solaris VM's from OCI Marketplace has following flaw:

The signatures in oci_marketplace_accepted_agreement are time based and expire over time, so that
if you have Solaris VM's running for quite some time already and then decide to update the terraform plan
and do subsequent "tofu apply" the update crashes with error message like this one:

```
module.worker.oci_marketplace_accepted_agreement.accepted_terms_of_service: Creating...
│ Error: 400-InvalidParameter, Expired signature for agreement (58993510) in listing (61750333) and version (11.4.71)
│ Suggestion: Please update the parameter(s) in the Terraform config as per error message Expired signature for agreement (58993510) in listing (61750333) and version (11.4.71)
│ Documentation: https://registry.terraform.io/providers/oracle/oci/latest/docs/resources/marketplace_accepted_agreement 
│ API Reference: https://docs.oracle.com/iaas/api/#/en/marketplace/20181001/AcceptedAgreement/CreateAcceptedAgreement 
│ Request Target: POST https://marketplace.us-phoenix-1.oci.oraclecloud.com/20181001/acceptedAgreements 
│ Provider version: 5.39.0, released on 2024-04-24. This provider is 22 Update(s) behind to current. 
│ Service: Marketplace Accepted Agreement 
│ Operation Name: CreateAcceptedAgreement 
│ OPC request ID: 731401d55231b822c02e4aa8ad929a23/29F1C30E12A9901DBABCFEF1DE78E28F/3E2055F1792FA6FA8B067148D8F9E3BB 
│ 
│ 
│   with module.worker.oci_marketplace_accepted_agreement.accepted_terms_of_service,
│   on ../oci_marketplace_host/marketplace.tf line 88, in resource "oci_marketplace_accepted_agreement" "accepted_terms_of_service":
│   88: resource "oci_marketplace_accepted_agreement" "accepted_terms_of_service" {
│ 
```

this pull request is trying to resolve that problem by forcing refresh of the package listings cached in terraform.tfstate that are older than 7 days, with fresh ones that do contain recently generated signatures.
