### PR TITLE
Adding sbom_generation.yml for enabling vulnerability scan by GCAS tool

### DIFF
--- a/sbom_generation.yaml
+++ b/sbom_generation.yaml
@@ -1,0 +1,42 @@
+# Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+
+# This OCI DevOps build specification file [1] generates a Software Bill of Materials (SBOM) of the repository.
+# The file is needed to run checks for third-party vulnerabilities and business approval according to Oracle’s GitHub policies.
+# [1] https://docs.oracle.com/en-us/iaas/Content/devops/using/build_specs.htm
+
+version: 0.1
+component: build
+timeoutInSeconds: 1000
+shell: bash
+env:
+  variables:
+    PYTHON_CMD: "python3"
+    CDXGEN_DEBUG_MODE: "debug"
+steps:
+  - type: Command
+    name: "Download the version 10.10.0 of cdxgen globally"
+    command: |
+      npm install -g @cyclonedx/cdxgen@10.10.0
+  - type: Command
+    name: "Workaround to let cdxgen run on nodejs 16"
+    command: |
+      # cdxgen relies on a fourth-party dependency that cannot be executed in a Node.js environment running version 16
+      # (as installed on the build runner instance)
+      # This is a workaround to ensure cdxgen functions correctly, even in an older Node.js environment.
+      cd /node/node-v16.14.2-linux-x64/lib/node_modules/@cyclonedx/cdxgen && \
+      npm install cheerio@v1.0.0-rc.12
+  - type: Command
+    name: "Generate SBOM for Python "
+    command: |
+      # Search the test or dev requirements files, so that test and dev py packages can be excluded in the generated SBOM
+      files=$(find . -type f -regex ".*\(test.*requirements\|requirements.*test\|dev.*requirements\|requirements.*dev\).*\.txt") && \
+      if [ -n "$files" ]; then \
+        cdxgen -t python -o artifactSBOM.json --spec-version 1.4 \
+        --exclude "*{requirements,dev,test}*{requirements,dev,test}*.txt" --project-name "$(basename $OCI_PRIMARY_SOURCE_URL)" --no-recurse
+      else \
+         cdxgen -t python -o artifactSBOM.json --spec-version 1.4 --project-name "$(basename $OCI_PRIMARY_SOURCE_URL)" --no-recurse
+      fi \
+outputArtifacts:
+  - name: artifactSBOM
+    type: BINARY
+    location: ${OCI_PRIMARY_SOURCE_DIR}/artifactSBOM.json


### PR DESCRIPTION
Hi repo maintainers,
The OGHO team scans all Oracle GitHub repos for vulnerabilities using GCAS tool. Unfortunately, the automatic scan for your repo failed, so the GCAS team recommends to create a custom SBOM file in this case. This PR adds such a file to this repo.
Can you please review and approve the PR?